### PR TITLE
fix: bmp388 section in main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -357,14 +357,14 @@ static void vario_task(void *pvParameter) {
             bmp388_sample();
             // KF4 uses the acceleration data in the update phase
             float zAccelAverage = ringbuf_averageNewestSamples(10); 
-            kalmanFilter4_predict(kfTimeDeltaUSecs/1000000.0f);
-            kalmanFilter4_update(ZCmSample_BMP388, zAccelAverage, (float*)&KFAltitudeCm, (float*)&KFClimbrateCps);
+            kalmanFilter4d_predict(kfTimeDeltaUSecs/1000000.0f);
+            kalmanFilter4d_update(ZCmSample_BMP388, zAccelAverage, (float*)&KFAltitudeCm, (float*)&KFClimbrateCps);
             kfTimeDeltaUSecs = 0.0f;
             // LCD display shows damped climbrate
             DisplayClimbrateCps = (DisplayClimbrateCps*(float)opt.vario.varioDisplayIIR + KFClimbrateCps*(100.0f - (float)opt.vario.varioDisplayIIR))/100.0f; 
             int32_t audioCps = INTEGER_ROUNDUP(KFClimbrateCps);
             if (IsSpeakerEnabled) {
-                beeper_beep(audioCps);                
+                vaudio_tick_handler(audioCps);                
                 }
 		    if ((opt.misc.logType == LOGTYPE_IBG) && FlashLogMutex) {
 		        if ( xSemaphoreTake( FlashLogMutex, portMAX_DELAY )) {


### PR DESCRIPTION
If the BMP388 sensor is selected the code is not successfully building. I changed the code to compile successfully but I'm still waiting for the hardware to arrive to verify that the fix works.